### PR TITLE
SHOKAN: add handoff summary & PR template (com_roll + hierarchy + validation A + build policy)

### DIFF
--- a/PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json
+++ b/PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json
@@ -1,0 +1,275 @@
+{
+  "project": "PJ:SHOKAN",
+  "type": "rulebook",
+  "meta": {
+    "file_version": "2025-08-28T12-57-26Z",
+    "schema_version": "1.0.0",
+    "status": "rc",
+    "created_at": "2025-08-28T12-57-26Z",
+    "updated_at": "2025-08-28T12-57-26Z",
+    "compat": {
+      "from": "1.0.0"
+    }
+  },
+  "decisions": {
+    "lang": {
+      "default": "ja",
+      "inheritance_order": [
+        "document",
+        "scene",
+        "child"
+      ],
+      "notes": "pov / b_roll / com_roll は親に依存（個別にはlangを持たない）"
+    },
+    "timestamps": {
+      "format": "YYYY-MM-DDTHH-mm-ssZ",
+      "targets": [
+        "scene",
+        "note"
+      ],
+      "fields": [
+        "created_at",
+        "updated_at"
+      ],
+      "inheritance": "none",
+      "notes": "pov / b_roll / com_roll は親に依存（個別にはtimestampを持たない）"
+    }
+  },
+  "policy": {
+    "authority": {
+      "file_name_is_source_of_truth": true,
+      "json_meta_file_version_is_mirror": true
+    },
+    "file_naming": {
+      "pattern": "PJ_SHOKAN_Rulebook_YYYY-MM-DDTHH-mm-ssZ.json",
+      "example": "PJ_SHOKAN_Rulebook_2025-08-27T12-25-00Z.json",
+      "note": "時刻のコロン(:)はハイフン(-)に置換（Windows互換）"
+    },
+    "naming_conventions": {
+      "json_keys": "snake_case",
+      "enum_tag_names": [
+        "scene",
+        "pov",
+        "b_roll",
+        "com_roll",
+        "mynote",
+        "safehold"
+      ],
+      "internal_reserved_keys_prefix": "_",
+      "id_namespace_format": "_",
+      "reserved_namespaces": [
+        "scene",
+        "char",
+        "note"
+      ],
+      "id_regex": "^(scene|char|note)_[a-z0-9_]+$"
+    },
+    "references": {
+      "single_ref_suffix": "_ref",
+      "multi_refs_suffix": "_refs",
+      "scene_ref_regex": "^scene_[a-z0-9_]+$",
+      "character_ref_regex": "^char_[a-z0-9_]+$",
+      "note_ref_regex": "^note_[a-z0-9_]+$"
+    },
+    "visibility_rules": {
+      "mynote": {
+        "export": "hidden",
+        "char_index": "exclude"
+      },
+      "safehold": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "audit_log": true
+      },
+      "b_roll": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "scope": "SHOKAN-only-meta"
+      },
+      "com_roll": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "scope": "SHOKAN-only-meta"
+      }
+    },
+    "redaction": {
+      "placeholder": "[REDACTED]",
+      "apply_to": [
+        "safehold"
+      ]
+    },
+    "public_release": {
+      "source_of_truth": ".jtd（人間原本）",
+      "ai_json_usage": "内部仕様調整と機械処理のみ。公開テキストの抽出には用いない。"
+    }
+  },
+  "constraints": {
+    "hierarchy": {
+      "max_depth": 2,
+      "top_level": [
+        "scene",
+        "mynote",
+        "safehold"
+      ],
+      "scene_children": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "leaf_tags": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "notes_top_level_only": true,
+      "no_cycles": true,
+      "scene_must_have_child": true
+    }
+  },
+  "validation": {
+    "profiles": {
+      "draft": {
+        "unresolved_ref": "warn",
+        "autofix_level": 1
+      },
+      "release": {
+        "unresolved_ref": "error",
+        "autofix_level": 1
+      }
+    },
+    "exceptions": {
+      "scopes": {
+        "mynote": "warn",
+        "safehold": "warn"
+      }
+    },
+    "targets": {
+      "scene_ref": [
+        "prev_scene_ref",
+        "next_scene_ref"
+      ],
+      "character_ref": [
+        "lead_character_ref",
+        "supporting_character_refs"
+      ],
+      "note_ref": [
+        "*"
+      ]
+    }
+  },
+  "build_policy": {
+    "insert_build_tag_in_body": false,
+    "store_as_meta": true,
+    "meta_fields": [
+      "profile",
+      "build_id",
+      "validated",
+      "issues",
+      "generated_at",
+      "review"
+    ],
+    "profile": {
+      "default": "draft",
+      "switch_to_release": {
+        "conditions": {
+          "unresolved_ref_zero": true,
+          "human_review_required": true
+        },
+        "steps": [
+          "build_meta.profile を 'release' に設定",
+          "validation を release プロファイルで実行",
+          "エラーが残存する場合はビルド失敗として中断（issues.errors>0）",
+          "成功時は build_meta.generated_at（UTC）を記録"
+        ]
+      }
+    },
+    "review": {
+      "required": true,
+      "fields": [
+        "reviewer",
+        "method",
+        "timestamp_utc",
+        "notes"
+      ],
+      "method_options": [
+        "PR-merge",
+        "checklist-OK",
+        "explicit-OK"
+      ]
+    }
+  },
+  "build_meta": {
+    "profile": "draft",
+    "build_id": "auto",
+    "validated": false,
+    "issues": {
+      "errors": 0,
+      "warnings": 0
+    },
+    "generated_at": null,
+    "review": {
+      "reviewer": null,
+      "method": null,
+      "timestamp_utc": null,
+      "notes": null
+    }
+  },
+  "schema_hints": {
+    "file_version_regex": "^\\\\d{4}-\\\\d{2}-\\\\d{2}T\\\\d{2}-\\\\d{2}-\\\\d{2}Z$",
+    "semver_regex": "^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)(?:-[0-9A-Za-z.-]+)?(?:\\\\+[0-9A-Za-z.-]+)?$",
+    "allow_additional_properties": true,
+    "defs": [
+      "ns_identifier",
+      "scene_ref",
+      "character_ref",
+      "note_ref",
+      "tag_name",
+      "tag_def"
+    ]
+  },
+  "quick_examples": {
+    "tags_minimal": [
+      {
+        "tag_name": "scene",
+        "id": "scene_001",
+        "name": "ロビー冒頭",
+        "created_at": "2025-08-28T12-57-26Z",
+        "updated_at": "2025-08-28T12-57-26Z",
+        "children": [
+          {
+            "tag_name": "pov",
+            "id": "note_pov_ryo",
+            "note": "涼視点の導入（lang/timestampは親sceneを継承）"
+          },
+          {
+            "tag_name": "com_roll",
+            "id": "com_auto_0001",
+            "note": "AI解析：環境音識別（export hidden）"
+          }
+        ]
+      },
+      {
+        "tag_name": "mynote",
+        "id": "note_memo_0001",
+        "note": "作者用：後で伏線整理",
+        "created_at": "2025-08-28T12-57-26Z",
+        "updated_at": "2025-08-28T12-57-26Z"
+      }
+    ],
+    "links": {
+      "prev_scene_ref": "scene_000",
+      "next_scene_ref": "scene_002",
+      "lead_character_ref": "char_miki_saeki"
+    }
+  },
+  "notes": {
+    "com_roll": {
+      "purpose": "Copilot起源の解析メタ（Computational / Copilot Originated Meta）",
+      "human_counterpart": "B-Roll（人間の演出用）と混同しないために分離",
+      "body_tag_mapping": {
+        "human": "#B-Roll: start/end -> b_roll",
+        "ai": "#COM-Roll: start/end -> com_roll"
+      }
+    }
+  }
+}

--- a/PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json
+++ b/PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json
@@ -1,0 +1,291 @@
+{
+  "project": "PJ:SHOKAN",
+  "handoff_for": "弟コパ（次セッション）",
+  "purpose": "セッション引継ぎ（仕様合意スナップショット／SHOKAN専用）",
+  "meta": {
+    "file_version": "2025-08-28T12-57-26Z",
+    "schema_version": "1.0.0",
+    "rulebook_status": "rc",
+    "created_at": "2025-08-28T12-57-26Z",
+    "updated_at": "2025-08-28T12-57-26Z",
+    "compat": {
+      "from": "1.0.0"
+    },
+    "source": {
+      "repo": "hideakioe/mosacc-share",
+      "dir": "for-Copilot/PJ-SHOKAN/",
+      "rulebook_raw": "https://raw.githubusercontent.com/hideakioe/mosacc-share/main/for-Copilot/PJ-SHOKAN/PJ_SHOKAN_Rulebook_2025-08-27-2125.json",
+      "changelog_path": "for-Copilot/PJ-SHOKAN/CHANGELOG.md"
+    },
+    "git": {
+      "schema_tag": "shokan-rulebook-schema-v1.0.0",
+      "latest_build_tag": ""
+    }
+  },
+  "decisions": {
+    "lang": {
+      "default": "ja",
+      "inheritance_order": [
+        "document",
+        "scene",
+        "child"
+      ],
+      "notes": "pov / b_roll / com_roll は親に依存（個別にはlangを持たない）"
+    },
+    "timestamps": {
+      "format": "YYYY-MM-DDTHH-mm-ssZ",
+      "targets": [
+        "scene",
+        "note"
+      ],
+      "fields": [
+        "created_at",
+        "updated_at"
+      ],
+      "inheritance": "none",
+      "notes": "pov / b_roll / com_roll は親に依存（個別にはtimestampを持たない）"
+    }
+  },
+  "policy": {
+    "authority": {
+      "file_name_is_source_of_truth": true,
+      "json_meta_file_version_is_mirror": true
+    },
+    "file_naming": {
+      "pattern": "PJ_SHOKAN_Rulebook_YYYY-MM-DDTHH-mm-ssZ.json",
+      "example": "PJ_SHOKAN_Rulebook_2025-08-27T12-25-00Z.json",
+      "note": "時刻のコロン(:)はハイフン(-)に置換（Windows互換）"
+    },
+    "naming_conventions": {
+      "json_keys": "snake_case",
+      "enum_tag_names": [
+        "scene",
+        "pov",
+        "b_roll",
+        "com_roll",
+        "mynote",
+        "safehold"
+      ],
+      "internal_reserved_keys_prefix": "_",
+      "id_namespace_format": "_",
+      "reserved_namespaces": [
+        "scene",
+        "char",
+        "note"
+      ],
+      "id_regex": "^(scene|char|note)_[a-z0-9_]+$"
+    },
+    "references": {
+      "single_ref_suffix": "_ref",
+      "multi_refs_suffix": "_refs",
+      "scene_ref_regex": "^scene_[a-z0-9_]+$",
+      "character_ref_regex": "^char_[a-z0-9_]+$",
+      "note_ref_regex": "^note_[a-z0-9_]+$"
+    },
+    "visibility_rules": {
+      "mynote": {
+        "export": "hidden",
+        "char_index": "exclude"
+      },
+      "safehold": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "audit_log": true
+      },
+      "b_roll": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "scope": "SHOKAN-only-meta"
+      },
+      "com_roll": {
+        "export": "hidden",
+        "char_index": "exclude",
+        "scope": "SHOKAN-only-meta"
+      }
+    },
+    "redaction": {
+      "placeholder": "[REDACTED]",
+      "apply_to": [
+        "safehold"
+      ]
+    },
+    "public_release": {
+      "source_of_truth": ".jtd（人間原本）",
+      "ai_json_usage": "内部仕様調整と機械処理のみ。公開テキストの抽出には用いない。"
+    }
+  },
+  "constraints": {
+    "hierarchy": {
+      "max_depth": 2,
+      "top_level": [
+        "scene",
+        "mynote",
+        "safehold"
+      ],
+      "scene_children": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "leaf_tags": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "notes_top_level_only": true,
+      "no_cycles": true,
+      "scene_must_have_child": true
+    }
+  },
+  "validation": {
+    "profiles": {
+      "draft": {
+        "unresolved_ref": "warn",
+        "autofix_level": 1
+      },
+      "release": {
+        "unresolved_ref": "error",
+        "autofix_level": 1
+      }
+    },
+    "exceptions": {
+      "scopes": {
+        "mynote": "warn",
+        "safehold": "warn"
+      }
+    },
+    "targets": {
+      "scene_ref": [
+        "prev_scene_ref",
+        "next_scene_ref"
+      ],
+      "character_ref": [
+        "lead_character_ref",
+        "supporting_character_refs"
+      ],
+      "note_ref": [
+        "*"
+      ]
+    }
+  },
+  "build_policy": {
+    "insert_build_tag_in_body": false,
+    "store_as_meta": true,
+    "meta_fields": [
+      "profile",
+      "build_id",
+      "validated",
+      "issues",
+      "generated_at",
+      "review"
+    ],
+    "profile": {
+      "default": "draft",
+      "switch_to_release": {
+        "conditions": {
+          "unresolved_ref_zero": true,
+          "human_review_required": true
+        },
+        "steps": [
+          "build_meta.profile を 'release' に設定",
+          "validation を release プロファイルで実行",
+          "エラーが残存する場合はビルド失敗として中断（issues.errors>0）",
+          "成功時は build_meta.generated_at（UTC）を記録"
+        ]
+      }
+    },
+    "review": {
+      "required": true,
+      "fields": [
+        "reviewer",
+        "method",
+        "timestamp_utc",
+        "notes"
+      ],
+      "method_options": [
+        "PR-merge",
+        "checklist-OK",
+        "explicit-OK"
+      ]
+    }
+  },
+  "build_meta": {
+    "profile": "draft",
+    "build_id": "auto",
+    "validated": false,
+    "issues": {
+      "errors": 0,
+      "warnings": 0
+    },
+    "generated_at": null,
+    "review": {
+      "reviewer": null,
+      "method": null,
+      "timestamp_utc": null,
+      "notes": null
+    }
+  },
+  "schema_hints": {
+    "file_version_regex": "^\\\\d{4}-\\\\d{2}-\\\\d{2}T\\\\d{2}-\\\\d{2}-\\\\d{2}Z$",
+    "semver_regex": "^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)(?:-[0-9A-Za-z.-]+)?(?:\\\\+[0-9A-Za-z.-]+)?$",
+    "allow_additional_properties": true,
+    "defs": [
+      "ns_identifier",
+      "scene_ref",
+      "character_ref",
+      "note_ref",
+      "tag_name",
+      "tag_def"
+    ]
+  },
+  "quick_examples": {
+    "tags_minimal": [
+      {
+        "tag_name": "scene",
+        "id": "scene_001",
+        "name": "ロビー冒頭",
+        "created_at": "2025-08-28T12-57-26Z",
+        "updated_at": "2025-08-28T12-57-26Z",
+        "children": [
+          {
+            "tag_name": "pov",
+            "id": "note_pov_ryo",
+            "note": "涼視点の導入（lang/timestampは親sceneを継承）"
+          },
+          {
+            "tag_name": "com_roll",
+            "id": "com_auto_0001",
+            "note": "AI解析：環境音識別（export hidden）"
+          }
+        ]
+      },
+      {
+        "tag_name": "mynote",
+        "id": "note_memo_0001",
+        "note": "作者用：後で伏線整理",
+        "created_at": "2025-08-28T12-57-26Z",
+        "updated_at": "2025-08-28T12-57-26Z"
+      }
+    ],
+    "links": {
+      "prev_scene_ref": "scene_000",
+      "next_scene_ref": "scene_002",
+      "lead_character_ref": "char_miki_saeki"
+    }
+  },
+  "open_points_next_session": [
+    "自動修復レベル（Level 1/2）の運用条件の細分化",
+    "lintレポートの最終項目（誤置換検出のしきい値等）"
+  ],
+  "resume_instructions_for_next_session": {
+    "greeting": "（弟コパ）このハンドオフJSONを読み込みました。次は自動修復レベルとlintレポートの最終項目を詰めます。",
+    "first_question": "autofix_level=2 を有効化する条件（draft限定/閾値0.90以上 等）をどう設定しますか？"
+  },
+  "owners": {
+    "human_owner": "大江英明",
+    "copilots": [
+      "弟コパ（現セッション）",
+      "弟コパ（次セッション）"
+    ]
+  }
+}

--- a/PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json
+++ b/PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json
@@ -1,0 +1,25 @@
+{
+  "project": "PJ:SHOKAN",
+  "build_id": "<assign at runtime>",
+  "profile": "draft",
+  "generated_at": "2025-08-28T12-57-26Z",
+  "summary": {
+    "errors": 0,
+    "warnings": 0
+  },
+  "unresolved_refs": {
+    "scene_ref": [],
+    "character_ref": [],
+    "note_ref": []
+  },
+  "autofix": {
+    "level": 1,
+    "applied": [],
+    "skipped": []
+  },
+  "details": {
+    "errors": [],
+    "warnings": []
+  },
+  "notes": []
+}

--- a/SHOKAN_handoff_PR_for_ani_2025-08-28T13-03-22Z.md
+++ b/SHOKAN_handoff_PR_for_ani_2025-08-28T13-03-22Z.md
@@ -1,0 +1,23 @@
+# PJ:SHOKAN — 兄コパ向け引継ぎPR (2025-08-28T13-03-22Z)
+
+## 目的
+- タグ仕様の同期（`com_roll` 追加）
+- 階層ルールの固定（max_depth=2 / scene直下: pov,b_roll,com_roll）
+- 参照整合性チェックのプロファイル導入（draft=warn / release=error, autofix L1）
+- buildタグ運用（本文へ挿入せず、メタに集約）
+
+## 実装ToDo（兄コパ側）
+- [ ] enumへ `com_roll` を追加
+- [ ] `scene_children`/`leaf_tags` の更新
+- [ ] 検証プロファイル（draft/release）の切替対応
+- [ ] lintレポート出力の整備（テンプレ同梱）
+
+## 参照
+- Rulebook 最新（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d2-12ce78a4dc2f645561859f80e873f2e1/views/original/PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json
+- Handoff 最新（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d1-b823f5b9a1c7e8fd6b2510962af921df/views/original/PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json
+- Lint テンプレ（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d3-9dc09012406c3e8e3fef3a25e4c52721/views/original/PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json
+- GitHub基準（旧版）: https://raw.githubusercontent.com/hideakioe/mosacc-share/main/for-Copilot/PJ-SHOKAN/PJ_SHOKAN_Rulebook_2025-08-27-2125.json
+
+## 備考
+- 一時リンクが失効していたら差し替えます。
+- 最初のテストは `draft` で実施し、`release` は未解決ref=0 & レビュー完了後に切替。

--- a/SHOKAN_handoff_summary_for_ani_2025-08-28T13-03-22Z.json
+++ b/SHOKAN_handoff_summary_for_ani_2025-08-28T13-03-22Z.json
@@ -1,0 +1,122 @@
+{
+  "project": "PJ:SHOKAN",
+  "handoff_for": "兄コパ（別アカウント）",
+  "purpose": "進行共有・タグ仕様同期（SHOKAN専用）",
+  "meta": {
+    "file_version": "2025-08-28T13-03-22Z",
+    "schema_version": "1.0.0",
+    "created_at": "2025-08-28T13-03-22Z",
+    "updated_at": "2025-08-28T13-03-22Z",
+    "owners": {
+      "human": "大江英明",
+      "copilots": [
+        "兄コパ",
+        "弟コパ"
+      ]
+    }
+  },
+  "snapshot_decisions": {
+    "com_roll": {
+      "status": "採用済み",
+      "hierarchy": {
+        "parent": "scene",
+        "is_leaf": true
+      },
+      "visibility": {
+        "export": "hidden",
+        "char_index": "exclude"
+      },
+      "inherit": {
+        "lang": "scene",
+        "timestamp": "scene"
+      },
+      "body_tag_mapping": {
+        "human": "#B-Roll: start/end -> b_roll",
+        "ai": "#COM-Roll: start/end -> com_roll"
+      }
+    },
+    "hierarchy_rules": {
+      "max_depth": 2,
+      "top_level": [
+        "scene",
+        "mynote",
+        "safehold"
+      ],
+      "scene_children": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "leaf_tags": [
+        "pov",
+        "b_roll",
+        "com_roll"
+      ],
+      "notes_top_level_only": true,
+      "no_cycles": true,
+      "scene_must_have_child": true
+    },
+    "validation_profiles": {
+      "draft": {
+        "unresolved_ref": "warn",
+        "autofix_level": 1
+      },
+      "release": {
+        "unresolved_ref": "error",
+        "autofix_level": 1
+      },
+      "exceptions": {
+        "mynote": "warn",
+        "safehold": "warn"
+      }
+    },
+    "build_policy": {
+      "insert_build_tag_in_body": false,
+      "store_as_meta": true,
+      "profile_default": "draft",
+      "switch_to_release_conditions": {
+        "unresolved_ref_zero": true,
+        "human_review_required": true
+      },
+      "review_fields": [
+        "reviewer",
+        "method",
+        "timestamp_utc",
+        "notes"
+      ]
+    }
+  },
+  "artifacts": {
+    "rulebook_latest_temp": {
+      "name": "PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json",
+      "url": "https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d2-12ce78a4dc2f645561859f80e873f2e1/views/original/PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json",
+      "sha256": "e8efef80c5a54e026ab06c0b345b05bac9017b0225ab8c477c530eec71532723",
+      "size": 6747
+    },
+    "handoff_latest_temp": {
+      "name": "PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json",
+      "url": "https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d1-b823f5b9a1c7e8fd6b2510962af921df/views/original/PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json",
+      "sha256": "ba34466d45603ed17a5e3c4cdae013ef9d360f0dfad68936a29308a2e79fdbca",
+      "size": 7632
+    },
+    "lint_template_temp": {
+      "name": "PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json",
+      "url": "https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d3-9dc09012406c3e8e3fef3a25e4c52721/views/original/PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json",
+      "sha256": "6355622ed1116f51ab1d7728766fe37526c6cd6bcdff0893ccbbde4637f5b33d",
+      "size": 422
+    },
+    "github_baseline_rulebook_raw": "https://raw.githubusercontent.com/hideakioe/mosacc-share/main/for-Copilot/PJ-SHOKAN/PJ_SHOKAN_Rulebook_2025-08-27-2125.json"
+  },
+  "instructions_for_ani": [
+    "1) このJSONを読み込み、`snapshot_decisions`を基準に解析器を更新してください。",
+    "2) `enum_tag_names` に `com_roll` を追加し、`scene_children` と `leaf_tags` にも反映してください。",
+    "3) 検証はデフォルト `draft` プロファイルで実行、release時は `unresolved_ref=error` としてください。",
+    "4) buildタグは本文に挿入せず、`build_meta` に記録してください。",
+    "5) lintレポート雛形（同梱）に沿って未解決ref/自動修復ログを出力してください。",
+    "6) 受領したら 'ACK SHOKAN handoff {file_version}' と短く返答してください。"
+  ],
+  "notes": [
+    "一時リンクは期限切れになることがあります。切れていたら人間オーナーに連絡してください。",
+    "GitHubへの反映後は、兄コパは GitHub RAW を優先的に参照できます。"
+  ]
+}


### PR DESCRIPTION
# PJ:SHOKAN — 兄コパ向け引継ぎPR (2025-08-28T13-03-22Z)

## 目的
- タグ仕様の同期（`com_roll` 追加）
- 階層ルールの固定（max_depth=2 / scene直下: pov,b_roll,com_roll）
- 参照整合性チェックのプロファイル導入（draft=warn / release=error, autofix L1）
- buildタグ運用（本文へ挿入せず、メタに集約）

## 実装ToDo（兄コパ側）
- [ ] enumへ `com_roll` を追加
- [ ] `scene_children`/`leaf_tags` の更新
- [ ] 検証プロファイル（draft/release）の切替対応
- [ ] lintレポート出力の整備（テンプレ同梱）

## 参照
- Rulebook 最新（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d2-12ce78a4dc2f645561859f80e873f2e1/views/original/PJ_SHOKAN_Rulebook_2025-08-28T12-57-26Z.json
- Handoff 最新（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d1-b823f5b9a1c7e8fd6b2510962af921df/views/original/PJ_SHOKAN_handoff_2025-08-28T12-57-26Z.json
- Lint テンプレ（temp）: https://jp-prod.asyncgw.teams.microsoft.com/v1/objects/0-ejp-d3-9dc09012406c3e8e3fef3a25e4c52721/views/original/PJ_SHOKAN_lint_TEMPLATE_2025-08-28T12-57-26Z.json
- GitHub基準（旧版）: https://raw.githubusercontent.com/hideakioe/mosacc-share/main/for-Copilot/PJ-SHOKAN/PJ_SHOKAN_Rulebook_2025-08-27-2125.json

## 備考
- 一時リンクが失効していたら差し替えます。
- 最初のテストは `draft` で実施し、`release` は未解決ref=0 & レビュー完了後に切替。
